### PR TITLE
[feat] Branch, PRs and Issue contexts also have recently visited behaviour for Quick Access

### DIFF
--- a/src/components/BranchListItem.tsx
+++ b/src/components/BranchListItem.tsx
@@ -5,12 +5,13 @@ import { BranchDetailsFragment, UserFieldsFragment } from "../generated/graphql"
 
 type BranchItemProps = {
   branch: BranchDetailsFragment;
-  mainBranch: string;
+  mainBranch?: string;
   viewer?: UserFieldsFragment;
   repository: string;
+  visitBranch?: (branch: BranchDetailsFragment, repository: string) => void;
 };
 
-export default function BranchListItem({ branch, mainBranch, repository }: BranchItemProps) {
+export default function BranchListItem({ branch, mainBranch, repository, visitBranch }: BranchItemProps) {
   const accessories: List.Item.Accessory[] = [];
   const branchURL = "https://github.com/" + repository + "/tree/" + branch.branchName;
 
@@ -58,7 +59,7 @@ export default function BranchListItem({ branch, mainBranch, repository }: Branc
   return (
     <List.Item
       icon={GitpodIcons.branchIcon}
-      subtitle={mainBranch}
+      subtitle={mainBranch ?? ""}
       title={branch.branchName}
       accessories={accessories}
       actions={
@@ -66,6 +67,7 @@ export default function BranchListItem({ branch, mainBranch, repository }: Branc
           <Action
             title="Open Branch in Gitpod"
             onAction={() => {
+              visitBranch?.(branch, repository)
               open(`https://gitpod.io/#${branchURL}`);
             }}
           />

--- a/src/components/IssueListItem.tsx
+++ b/src/components/IssueListItem.tsx
@@ -14,12 +14,13 @@ type IssueListItemProps = {
   issue: IssueFieldsFragment;
   viewer?: UserFieldsFragment;
   mutateList?:
-    | MutatePromise<SearchCreatedIssuesQuery | undefined>
-    | MutatePromise<SearchOpenIssuesQuery | undefined>
-    | MutatePromise<IssueFieldsFragment[] | undefined>;
+  | MutatePromise<SearchCreatedIssuesQuery | undefined>
+  | MutatePromise<SearchOpenIssuesQuery | undefined>
+  | MutatePromise<IssueFieldsFragment[] | undefined>;
+  visitIssue?: (issue: IssueFieldsFragment) => void;
 };
 
-export default function IssueListItem({ issue }: IssueListItemProps) {
+export default function IssueListItem({ issue, visitIssue }: IssueListItemProps) {
   const updatedAt = new Date(issue.updatedAt);
 
   const author = getIssueAuthor(issue);
@@ -62,6 +63,7 @@ export default function IssueListItem({ issue }: IssueListItemProps) {
           <Action
             title="Open Issue in Gitpod"
             onAction={() => {
+              visitIssue?.(issue)
               open(`https://gitpod.io/#${issue.url}`);
             }}
           />

--- a/src/components/PullRequestListItem.tsx
+++ b/src/components/PullRequestListItem.tsx
@@ -18,10 +18,11 @@ import {
 type PullRequestListItemProps = {
   pullRequest: PullRequestFieldsFragment;
   viewer?: UserFieldsFragment;
+  visitPullReq?: (pullRequest: PullRequestFieldsFragment) => void;
   // mutateList: MutatePromise<MyPullRequestsQuery | undefined> | MutatePromise<PullRequestFieldsFragment[] | undefined>;
 };
 
-export default function PullRequestListItem({ pullRequest, viewer }: PullRequestListItemProps) {
+export default function PullRequestListItem({ pullRequest, viewer, visitPullReq }: PullRequestListItemProps) {
   const updatedAt = new Date(pullRequest.updatedAt);
 
   const numberOfComments = useMemo(() => getNumberOfComments(pullRequest), []);
@@ -79,6 +80,7 @@ export default function PullRequestListItem({ pullRequest, viewer }: PullRequest
           <Action
             title="Open PR in Gitpod"
             onAction={() => {
+              visitPullReq?.(pullRequest)
               open(`https://gitpod.io/#${pullRequest.permalink}`);
             }}
           />

--- a/src/helpers/branch.ts
+++ b/src/helpers/branch.ts
@@ -1,0 +1,41 @@
+import { LocalStorage } from "@raycast/api";
+import { useCachedState } from "@raycast/utils";
+import { useEffect } from "react";
+
+import { BranchDetailsFragment } from "../generated/graphql";
+
+const VISITED_BRANCH_KEY = "VISITED_BRANCHES";
+const VISITED_BRANCH_LENGTH = 10;
+
+// History was stored in `LocalStorage` before, after migration it's stored in `Cache`
+async function loadVisitedBranches() {
+  const item = await LocalStorage.getItem<string>(VISITED_BRANCH_KEY);
+  if (item) {
+    const parsed = JSON.parse(item).slice(0, VISITED_BRANCH_LENGTH);
+    return parsed as BranchDetailsFragment[];
+  } else {
+    return [];
+  }
+}
+export function useBranchHistory() {
+  const [history, setHistory] = useCachedState<BranchDetailsFragment[]>("BranchHistory", []);
+  const [migratedHistory, setMigratedHistory] = useCachedState<boolean>("migratedBranchHistory", false);
+
+  useEffect(() => {
+    if (!migratedHistory) {
+      loadVisitedBranches().then((branches) => {
+        setHistory(branches);
+        setMigratedHistory(true);
+      });
+    }
+  }, [migratedHistory]);
+
+  function visitBranch(branch: BranchDetailsFragment) {
+    const visitedBranch = [branch, ...(history?.filter((item) => item.branchName !== branch.branchName) ?? [])];
+    LocalStorage.setItem(VISITED_BRANCH_KEY, JSON.stringify(visitedBranch));
+    const nextBranch = visitedBranch.slice(0, VISITED_BRANCH_LENGTH);
+    setHistory(nextBranch);
+  }
+
+  return { history, visitBranch };
+}

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -1,8 +1,47 @@
 import { Color } from "@raycast/api";
+import { LocalStorage } from "@raycast/api";
+import { useCachedState } from "@raycast/utils";
+import { useEffect } from "react";
 
 import { IssueDetailFieldsFragment, IssueFieldsFragment, IssueStateReason } from "../generated/graphql";
 
 import { getGitHubUser } from "./users";
+
+const VISITED_ISSUE_KEY = "VISITED_ISSUE";
+const VISITED_ISSUE_LENGTH = 10;
+
+// History was stored in `LocalStorage` before, after migration it's stored in `Cache`
+async function loadVisitedIssues() {
+  const item = await LocalStorage.getItem<string>(VISITED_ISSUE_KEY);
+  if (item) {
+    const parsed = JSON.parse(item).slice(0, VISITED_ISSUE_LENGTH);
+    return parsed as IssueFieldsFragment[];
+  } else {
+    return [];
+  }
+}
+export function useIssueHistory() {
+  const [history, setHistory] = useCachedState<IssueFieldsFragment[]>("IssueHistory", []);
+  const [migratedHistory, setMigratedHistory] = useCachedState<boolean>("migratedIssueHistory", false);
+
+  useEffect(() => {
+    if (!migratedHistory) {
+      loadVisitedIssues().then((issues) => {
+        setHistory(issues);
+        setMigratedHistory(true);
+      });
+    }
+  }, [migratedHistory]);
+
+  function visitIssue(issue: IssueFieldsFragment) {
+    const visitedIssues = [issue, ...(history?.filter((item) => item.id !== issue.id) ?? [])];
+    LocalStorage.setItem(VISITED_ISSUE_KEY, JSON.stringify(visitedIssues));
+    const nextIssue = visitedIssues.slice(0, VISITED_ISSUE_LENGTH);
+    setHistory(nextIssue);
+  }
+
+  return { history, visitIssue };
+}
 
 export function getIssueStatus(issue: IssueFieldsFragment | IssueDetailFieldsFragment) {
   if (issue.stateReason === IssueStateReason.NotPlanned) {

--- a/src/helpers/pull-request.ts
+++ b/src/helpers/pull-request.ts
@@ -1,5 +1,8 @@
 import { List, Color, Icon } from "@raycast/api";
+import { LocalStorage } from "@raycast/api";
+import { useCachedState } from "@raycast/utils";
 import { uniqBy } from "lodash";
+import { useEffect } from "react";
 
 import {
   PullRequestDetailsFieldsFragment,
@@ -9,6 +12,42 @@ import {
 } from "../generated/graphql";
 
 import { getGitHubUser } from "./users";
+
+const VISITED_PULL_REQ_KEY = "VISITED_PULL_REQUESTS";
+const VISITED_PULL_REQ_LENGTH = 10;
+
+// History was stored in `LocalStorage` before, after migration it's stored in `Cache`
+async function loadVisitedRepositories() {
+  const item = await LocalStorage.getItem<string>(VISITED_PULL_REQ_KEY);
+  if (item) {
+    const parsed = JSON.parse(item).slice(0, VISITED_PULL_REQ_LENGTH);
+    return parsed as PullRequestFieldsFragment[];
+  } else {
+    return [];
+  }
+}
+export function usePullReqHistory() {
+  const [history, setHistory] = useCachedState<PullRequestFieldsFragment[]>("PullReqHistory", []);
+  const [migratedHistory, setMigratedHistory] = useCachedState<boolean>("migratedPullReqHistory", false);
+
+  useEffect(() => {
+    if (!migratedHistory) {
+      loadVisitedRepositories().then((repositories) => {
+        setHistory(repositories);
+        setMigratedHistory(true);
+      });
+    }
+  }, [migratedHistory]);
+
+  function visitPullReq(pullRequest: PullRequestFieldsFragment) {
+    const visitedPullReq = [pullRequest, ...(history?.filter((item) => item.id !== pullRequest.id) ?? [])];
+    LocalStorage.setItem(VISITED_PULL_REQ_KEY, JSON.stringify(visitedPullReq));
+    const nextPullReq = visitedPullReq.slice(0, VISITED_PULL_REQ_LENGTH);
+    setHistory(nextPullReq);
+  }
+
+  return { history, visitPullReq };
+}
 
 export function getPullRequestStatus(pullRequest: PullRequestFieldsFragment | PullRequestDetailsFieldsFragment) {
   if (pullRequest.merged) {

--- a/src/open_in_gitpod.tsx
+++ b/src/open_in_gitpod.tsx
@@ -2,11 +2,17 @@ import { List, showToast, Toast } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { useState, useMemo } from "react";
 
+import BranchListItem from "./components/BranchListItem";
+import IssueListItem from "./components/IssueListItem";
+import PullRequestListItem from "./components/PullRequestListItem";
 import RepositoryListEmptyView from "./components/RepositoryListEmptyView";
 import RepositoryListItem from "./components/RepositoryListItem";
 import SearchRepositoryDropdown from "./components/SearchRepositoryDropdown";
 import View from "./components/View";
 import { ExtendedRepositoryFieldsFragment } from "./generated/graphql";
+import { useBranchHistory } from "./helpers/branch";
+import { useIssueHistory } from "./helpers/issue";
+import { usePullReqHistory } from "./helpers/pull-request";
 import { useHistory } from "./helpers/repository";
 import { getGitHubClient } from "./helpers/withGithubClient";
 
@@ -16,6 +22,10 @@ function SearchRepositories() {
   const [searchText, setSearchText] = useState("");
   const [searchFilter, setSearchFilter] = useState<string | null>(null);
   const { data: history, visitRepository } = useHistory(searchText, searchFilter);
+  const { history: visitedPullReqs } = usePullReqHistory();
+  const { history: visitedBranches } = useBranchHistory();
+  const { history: visitedIssues } = useIssueHistory();
+
   const [gitpodArray, setGitpodArray] = useState<string[]>();
   const query = useMemo(() => `${searchFilter} ${searchText} fork:true`, [searchText, searchFilter]);
 
@@ -69,6 +79,19 @@ function SearchRepositories() {
       searchBarAccessory={<SearchRepositoryDropdown onFilterChange={setSearchFilter} />}
       throttle
     >
+      <List.Section title="Recent Contexts" subtitle={history ? String(history.length) : undefined}>
+        {visitedBranches.map((branch, index) => (
+          <BranchListItem
+            branch={branch}
+            key={index} />
+        ))}
+        {visitedPullReqs.map((pullRequest) => (
+          <PullRequestListItem key={pullRequest.id} pullRequest={pullRequest} />
+        ))}
+        {visitedIssues.map((issue) => (
+          <IssueListItem key={issue.id} issue={issue} />
+        ))}
+      </List.Section>
       <List.Section title="Recent Repositories" subtitle={history ? String(history.length) : undefined}>
         {history.map((repository) => (
           <RepositoryListItem

--- a/src/open_in_gitpod.tsx
+++ b/src/open_in_gitpod.tsx
@@ -79,7 +79,7 @@ function SearchRepositories() {
       searchBarAccessory={<SearchRepositoryDropdown onFilterChange={setSearchFilter} />}
       throttle
     >
-      <List.Section title="Recent Contexts" subtitle={history ? String(history.length) : undefined}>
+      {searchText == "" && (<List.Section title="Recent Contexts" subtitle={(visitedBranches || visitedPullReqs || visitedIssues) ? String(visitedBranches?.length + visitedPullReqs?.length + visitedIssues?.length) : undefined}>
         {visitedBranches.map((branch, index) => (
           <BranchListItem
             branch={branch}
@@ -91,7 +91,7 @@ function SearchRepositories() {
         {visitedIssues.map((issue) => (
           <IssueListItem key={issue.id} issue={issue} />
         ))}
-      </List.Section>
+      </List.Section>)}
       <List.Section title="Recent Repositories" subtitle={history ? String(history.length) : undefined}>
         {history.map((repository) => (
           <RepositoryListItem

--- a/src/open_repo_context.tsx
+++ b/src/open_repo_context.tsx
@@ -13,6 +13,9 @@ import {
   PullRequestFieldsFragment,
 } from "./generated/graphql";
 import { pluralize } from "./helpers";
+import { useBranchHistory } from "./helpers/branch";
+import { useIssueHistory } from "./helpers/issue";
+import { usePullReqHistory } from "./helpers/pull-request";
 import { getGitHubClient } from "./helpers/withGithubClient";
 import { useViewer } from "./hooks/useViewer";
 
@@ -25,6 +28,9 @@ const cache = new Cache();
 function SearchContext({ repository }: SearchContextProps) {
   const { github } = getGitHubClient();
   const viewer = useViewer();
+  const { visitPullReq } = usePullReqHistory();
+  const { visitBranch } = useBranchHistory();
+  const { visitIssue } = useIssueHistory();
   const [sections, setSections] = useState(["/b", "/i", "/p"]);
 
   const [searchText, setSearchText] = useState("");
@@ -50,9 +56,8 @@ function SearchContext({ repository }: SearchContextProps) {
       if (sections.includes("/p")) {
         const pullRequest = (
           await github.searchPullRequests({
-            query: `is:pr repo:${repository.nameWithOwner} ${
-              forAuthor ? "author:@me" : ""
-            } archived:false ${searchText.trim()}`,
+            query: `is:pr repo:${repository.nameWithOwner} ${forAuthor ? "author:@me" : ""
+              } archived:false ${searchText.trim()}`,
             numberOfItems: n,
           })
         ).search.edges?.map((edge) => edge?.node as PullRequestFieldsFragment);
@@ -62,9 +67,8 @@ function SearchContext({ repository }: SearchContextProps) {
       if (sections.includes("/i")) {
         const issues = (
           await github.searchIssues({
-            query: `is:issue repo:${repository.nameWithOwner} ${
-              forAuthor ? "author:@me" : ""
-            } archived:false ${searchText.trim()}`,
+            query: `is:issue repo:${repository.nameWithOwner} ${forAuthor ? "author:@me" : ""
+              } archived:false ${searchText.trim()}`,
             numberOfItems: n,
           })
         ).search.nodes?.map((node) => node as IssueFieldsFragment);
@@ -162,6 +166,7 @@ function SearchContext({ repository }: SearchContextProps) {
                   repository={forAuthor ? `${viewer?.login}/${repository.name}` : repository.nameWithOwner}
                   branch={branch}
                   viewer={viewer}
+                  visitBranch={visitBranch}
                 />
               );
             })}
@@ -179,7 +184,7 @@ function SearchContext({ repository }: SearchContextProps) {
             {JSON.parse(cache.get(repository.nameWithOwner)!).pullRequest.map(
               (pullRequest: PullRequestFieldsFragment) => {
                 if (!pullRequest.closed) {
-                  return <PullRequestListItem key={pullRequest.id} pullRequest={pullRequest} viewer={viewer} />;
+                  return <PullRequestListItem key={pullRequest.id} pullRequest={pullRequest} viewer={viewer} visitPullReq={visitPullReq} />;
                 }
               }
             )}
@@ -195,7 +200,7 @@ function SearchContext({ repository }: SearchContextProps) {
             })}
           >
             {JSON.parse(cache.get(repository.nameWithOwner)!).issues.map((issue: IssueFieldsFragment) => {
-              return <IssueListItem key={issue.id} issue={issue} viewer={viewer} />;
+              return <IssueListItem key={issue.id} issue={issue} viewer={viewer} visitIssue={visitIssue} />;
             })}
           </List.Section>
         )}
@@ -224,6 +229,7 @@ function SearchContext({ repository }: SearchContextProps) {
                 mainBranch={repository.defaultBranchRef?.defaultBranch ?? ""}
                 repository={forAuthor ? `${viewer?.login}/${repository.name}` : repository.nameWithOwner}
                 branch={branch}
+                visitBranch={visitBranch}
                 viewer={viewer}
               />
             );
@@ -239,7 +245,7 @@ function SearchContext({ repository }: SearchContextProps) {
         >
           {data.pullRequest.map((pullRequest) => {
             if (!pullRequest.closed) {
-              return <PullRequestListItem key={pullRequest.id} pullRequest={pullRequest} viewer={viewer} />;
+              return <PullRequestListItem key={pullRequest.id} pullRequest={pullRequest} viewer={viewer} visitPullReq={visitPullReq} />;
             }
           })}
         </List.Section>
@@ -252,7 +258,7 @@ function SearchContext({ repository }: SearchContextProps) {
           subtitle={pluralize(data?.issues.length, "Issue", { withNumber: true })}
         >
           {data.issues.map((issue) => {
-            return <IssueListItem key={issue.id} issue={issue} viewer={viewer} />;
+            return <IssueListItem key={issue.id} issue={issue} viewer={viewer} visitIssue={visitIssue} />;
           })}
         </List.Section>
       )}


### PR DESCRIPTION
Added behaviour of Recent Contexts in the main command's cached page

<img width="1000" alt="gitpod 2023-03-06 at 01 24 20" src="https://user-images.githubusercontent.com/73993394/222982618-aa93a244-cf30-4859-a931-1da5a722421c.png">

Current behaviour: 
1. User opens any Branch, PR or Issue, then they'll be shown via caching on the initial screen for quicker access

Needed improvements:
1. Show the "repo-org/repo-name" side-by-side to the contexts by removing some components in the Respective Context List Items

Decisions needed to be made:
1. How many recent contexts and how many recent repositories for best user experience?