### PR TITLE
[fix] Cache invalidation for filter params /me, /p, /b and /i i.e. sections added

### DIFF
--- a/src/open_repo_context.tsx
+++ b/src/open_repo_context.tsx
@@ -33,7 +33,7 @@ function SearchContext({ repository }: SearchContextProps) {
   const [firstLoad, setfirstLoad] = useState(true);
 
   const { data, isLoading: isPRLoading } = usePromise(
-    async (searchText) => {
+    async (searchText, sections) => {
       const result: {
         pullRequest?: PullRequestFieldsFragment[] | undefined;
         issues?: IssueFieldsFragment[] | undefined;
@@ -50,9 +50,8 @@ function SearchContext({ repository }: SearchContextProps) {
       if (sections.includes("/p")) {
         const pullRequest = (
           await github.searchPullRequests({
-            query: `is:pr repo:${repository.nameWithOwner} ${
-              forAuthor ? "author:@me" : ""
-            } archived:false ${searchText.trim()}`,
+            query: `is:pr repo:${repository.nameWithOwner} ${forAuthor ? "author:@me" : ""
+              } archived:false ${searchText.trim()}`,
             numberOfItems: n,
           })
         ).search.edges?.map((edge) => edge?.node as PullRequestFieldsFragment);
@@ -62,9 +61,8 @@ function SearchContext({ repository }: SearchContextProps) {
       if (sections.includes("/i")) {
         const issues = (
           await github.searchIssues({
-            query: `is:issue repo:${repository.nameWithOwner} ${
-              forAuthor ? "author:@me" : ""
-            } archived:false ${searchText.trim()}`,
+            query: `is:issue repo:${repository.nameWithOwner} ${forAuthor ? "author:@me" : ""
+              } archived:false ${searchText.trim()}`,
             numberOfItems: n,
           })
         ).search.nodes?.map((node) => node as IssueFieldsFragment);
@@ -90,7 +88,7 @@ function SearchContext({ repository }: SearchContextProps) {
 
       return result;
     },
-    [searchText],
+    [searchText, sections],
     {
       onError(error) {
         showToast({


### PR DESCRIPTION
## Issue

A weird bug when repeated filtering stops giving results unexpectedly

![rerenderbug](https://user-images.githubusercontent.com/73993394/225303587-dbb31b6a-07dd-494f-a66b-a85c7a0bec4e.gif)

## Fix

Now the cache is invalidated for every change of filter params (/me, /i, /b and /p)

