### PR TITLE
Use preference value for Gitpod endpoint everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
       "name": "gitpodUrl",
       "title": "Gitpod's URL Endpoint",
       "placeholder": "https://custom-gitpod-host",
+      "default": "https://gitpod.io",
       "description": "Configure your custom Gitpod URL for Dedicated and Self-Hosted",
       "type": "textfield",
       "required": false

--- a/src/components/TemplateListItem.tsx
+++ b/src/components/TemplateListItem.tsx
@@ -1,7 +1,8 @@
-import { List, ActionPanel, Action, showToast, Toast, open } from "@raycast/api";
+import { List, ActionPanel, Action, showToast, Toast, open, getPreferenceValues } from "@raycast/api";
 
 import { GitpodIcons } from "../../constants";
 import { getGitHubUser } from "../helpers/users";
+import { getGitpodEndpoint } from "../preferences/gitpod_endpoint";
 
 type RepositoryListItemProps = {
   repository: {
@@ -18,6 +19,7 @@ type RepositoryListItemProps = {
 export default function TemplateListItem({ repository }: RepositoryListItemProps) {
   const owner = getGitHubUser(repository.owner);
   const numberOfStars = repository.stargazerCount;
+  const gitpodEndpoint = getGitpodEndpoint();
 
   const accessories: List.Item.Accessory[] = [];
 
@@ -28,7 +30,7 @@ export default function TemplateListItem({ repository }: RepositoryListItemProps
         style: Toast.Style.Success,
       });
       setTimeout(() => {
-        open(`https://gitpod.io/#${repository.url}`);
+        open(`${gitpodEndpoint}/#${repository.url}`);
       }, 1500);
     } catch (error) {
       await showToast({

--- a/src/helpers/openInGitpod.ts
+++ b/src/helpers/openInGitpod.ts
@@ -1,11 +1,11 @@
 import { LocalStorage, open, showToast, Toast } from "@raycast/api";
 import { getPreferenceValues } from "@raycast/api";
+import { getGitpodEndpoint } from "../preferences/gitpod_endpoint";
 
 interface Preferences {
   preferredEditor: string;
   useLatest: boolean;
   preferredEditorClass: "g1-standard" | "g1-large";
-  gitpodUrl?: string;
 }
 
 export async function getPreferencesForContext(
@@ -42,7 +42,7 @@ export default async function OpenInGitpod(
   repository: string,
   context?: string
 ) {
-  const defaultPreferences = getPreferenceValues<Preferences>();
+  const gitpodEndpoint = getGitpodEndpoint();
   const preferences = await getPreferencesForContext(type, repository, context);
   if (type === "Branch") {
     //visit branch
@@ -52,8 +52,6 @@ export default async function OpenInGitpod(
     //visit issue
   }
 
-  const gitpodUrl = defaultPreferences.gitpodUrl ?? "https://gitpod.io";
-
   try {
     await showToast({
       title: "Launching your workspace",
@@ -61,7 +59,7 @@ export default async function OpenInGitpod(
     });
     setTimeout(() => {
       open(
-        `${gitpodUrl}/?useLatest=${preferences.useLatest}&editor=${preferences.preferredEditor}${
+        `${gitpodEndpoint}/?useLatest=${preferences.useLatest}&editor=${preferences.preferredEditor}${
           preferences.useLatest ? "-latest" : ""
         }&workspaceClass=${preferences.preferredEditorClass}#${contextUrl}`
       );

--- a/src/menubar.tsx
+++ b/src/menubar.tsx
@@ -3,9 +3,11 @@ import { MenuBarExtra, open } from "@raycast/api";
 import { GitpodIcons } from "../constants";
 
 import { useHistory } from "./helpers/repository";
+import { getGitpodEndpoint } from "./preferences/gitpod_endpoint";
 
 export default function Command() {
   const { data } = useHistory("", "");
+  const gitpodEndpoint = getGitpodEndpoint();
 
   return (
     <MenuBarExtra icon={GitpodIcons.gitpod_logo_primary}>
@@ -15,7 +17,7 @@ export default function Command() {
             key={repository.nameWithOwner}
             title={repository.nameWithOwner}
             icon={GitpodIcons.repoIcon}
-            onAction={() => open(`https://gitpod.io#https://github.com/${repository.nameWithOwner}`)}
+            onAction={() => open(`${gitpodEndpoint}#https://github.com/${repository.nameWithOwner}`)}
           />
         ))}
       </MenuBarExtra.Section>

--- a/src/preferences/gitpod_endpoint.tsx
+++ b/src/preferences/gitpod_endpoint.tsx
@@ -1,0 +1,6 @@
+import { getPreferenceValues } from "@raycast/api";
+
+export function getGitpodEndpoint(): string {
+  const { gitpodUrl } = getPreferenceValues();
+  return gitpodUrl;
+}


### PR DESCRIPTION
Following up on https://github.com/raycast/extensions/pull/5457 - the changes are different here as the code-bases have diverged, but the intention is the same. Most of the work was already done in this repository, so I just grep'ed for the remaining hardcoded references to gitpod.io and changed them to use the preference value instead. ☺️

I did some very basic testing of this:

```sh 
npm run build # Just to check that I didn't break the build
npm run dev   # To install the extension
# Change the preference value to our Gitpod-internal dogfooding endpoint
# Opened a workspace to ensure it did indeed use endpoint (it did)
```

