### PR TITLE
Use the Gitpod endpoint from the preferences everywhere

### DIFF
--- a/src/api/Gitpod/Models/IOrganizations.ts
+++ b/src/api/Gitpod/Models/IOrganizations.ts
@@ -1,10 +1,13 @@
 import fetch from "node-fetch";
 
+import { getPublicAPIEndpoint } from "../../../preferences/gitpod_endpoint";
+
 import { IOrganizationError } from "./IOrganizationError";
 import { GitpodDataModel } from "./Model";
 
+const publicAPIEndpoint = getPublicAPIEndpoint();
 const organizationURLs = {
-  getOrganizations: "https://api.gitpod.io/gitpod.experimental.v1.TeamsService/ListTeams",
+  getOrganizations: `${publicAPIEndpoint}/gitpod.experimental.v1.TeamsService/ListTeams`,
 };
 
 export class IOrganization implements GitpodDataModel {

--- a/src/api/Gitpod/Models/IWorkspace.ts
+++ b/src/api/Gitpod/Models/IWorkspace.ts
@@ -1,5 +1,6 @@
 import fetch from "node-fetch";
 
+import { getPublicAPIEndpoint, getGitpodEndpoint } from "../../../preferences/gitpod_endpoint";
 import { CreateWorkspace, WorkspaceStreamer } from "../WorkspaceStreamer";
 
 import { IWorkspaceError } from "./IWorkspaceError";
@@ -21,12 +22,13 @@ type ICreateWorkspaceParams = {
   };
 };
 
+const publicAPIEndpoint = getPublicAPIEndpoint();
 const workspaceURLs = {
-  getWorkspace: "https://api.gitpod.io/gitpod.experimental.v1.WorkspacesService/GetWorkspace",
-  getAllWorkspaces: "https://api.gitpod.io/gitpod.experimental.v1.WorkspacesService/ListWorkspaces",
-  deleteWorkspace: "https://api.gitpod.io/gitpod.experimental.v1.WorkspacesService/DeleteWorkspace",
-  startWorkspace: "https://api.gitpod.io/gitpod.experimental.v1.WorkspacesService/StartWorkspace",
-  stopWorkspace: "https://api.gitpod.io/gitpod.experimental.v1.WorkspacesService/StopWorkspace",
+  getWorkspace: `${publicAPIEndpoint}/gitpod.experimental.v1.WorkspacesService/GetWorkspace`,
+  getAllWorkspaces: `${publicAPIEndpoint}/gitpod.experimental.v1.WorkspacesService/ListWorkspaces`,
+  deleteWorkspace: `${publicAPIEndpoint}/gitpod.experimental.v1.WorkspacesService/DeleteWorkspace`,
+  startWorkspace: `${publicAPIEndpoint}/gitpod.experimental.v1.WorkspacesService/StartWorkspace`,
+  stopWorkspace: `${publicAPIEndpoint}/gitpod.experimental.v1.WorkspacesService/StopWorkspace`,
 };
 
 export class IWorkspace implements GitpodDataModel {
@@ -159,7 +161,7 @@ export class IWorkspace implements GitpodDataModel {
     this.instanceId = workspace.status.instance.instanceId;
     this.initialized = true;
     this.createdAt = workspace.status.instance.createdAt;
-    this.ideURL = workspace.status.instance ? workspace.status.instance.status.url : "https://gitpod.io";
+    this.ideURL = workspace.status.instance ? workspace.status.instance.status.url : getGitpodEndpoint();
     this.repository = workspace.context.git.repository.name;
 
     if (workspace.status.instance.status.gitStatus) {

--- a/src/api/Gitpod/WorkspaceStreamer.ts
+++ b/src/api/Gitpod/WorkspaceStreamer.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from "events";
 
 import WebSocket from "ws";
 
+import { getGitpodEndpoint, getWebsocketEndpoint } from "../../preferences/gitpod_endpoint";
+
 import { NewIWorkspaceErrorObject } from "./Models/IWorkspaceError";
 import { NewIWorkspaceUpdateObject } from "./Models/IWorkspaceUpdate";
 
@@ -44,12 +46,15 @@ export class WorkspaceStreamer extends EventEmitter {
 
   constructor(token: string) {
     super();
+
+    const gitpodEndpoint = getGitpodEndpoint();
+    const gitpodWebsocketEndpoint = getWebsocketEndpoint();
     try {
       WorkspaceStreamer.token = token;
       // Create new transport for GRPC Messages
-      WorkspaceStreamer.webSocket = new WebSocket("wss://gitpod.io/api/v1", {
+      WorkspaceStreamer.webSocket = new WebSocket(`${gitpodWebsocketEndpoint}/api/v1`, {
         headers: {
-          Origin: new URL("https://gitpod.io").origin,
+          Origin: new URL(gitpodEndpoint).origin,
           Authorization: `Bearer ${token}`,
         },
       });

--- a/src/helpers/getVSCodeEncodedURI.ts
+++ b/src/helpers/getVSCodeEncodedURI.ts
@@ -1,10 +1,12 @@
 import { IWorkspace } from "../api/Gitpod/Models/IWorkspace";
+import { getGitpodEndpoint } from "../preferences/gitpod_endpoint";
 
 export function getCodeEncodedURI(workspace: IWorkspace): string {
+  const gitpodEndpoint = getGitpodEndpoint();
   const data = {
     instanceId: workspace.instanceId,
     workspaceId: workspace.getWorkspaceId(),
-    gitpodHost: "https://gitpod.io",
+    gitpodHost: gitpodEndpoint,
   };
 
   const vsCodeURI =

--- a/src/menubar_workspaces.tsx
+++ b/src/menubar_workspaces.tsx
@@ -22,11 +22,13 @@ import { getFocusedBrowserContext } from "./helpers/getFocusedContext";
 import { getCodeEncodedURI } from "./helpers/getVSCodeEncodedURI";
 import { splitUrl } from "./helpers/splitURL";
 import { dashboardPreferences } from "./preferences/dashboard_preferences";
+import { getGitpodEndpoint } from "./preferences/gitpod_endpoint";
 import { Preferences } from "./preferences/repository_preferences";
 
 export default function command() {
   const preferences = getPreferenceValues<dashboardPreferences>();
   const EditorPreferences = getPreferenceValues<Preferences>();
+  const gitpodEndpoint = getGitpodEndpoint();
   const [isUnauthorised, setIsUnauthorized] = useState<boolean>(false);
 
   const workspaceManager = new WorkspaceManager(preferences.access_token ?? "");
@@ -199,19 +201,19 @@ export default function command() {
           title="Dashboard"
           icon={GitpodIcons.dashboard_icon}
           shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
-          onAction={() => open("https://gitpod.io/workspaces")}
+          onAction={() => open(`${gitpodEndpoint}/workspaces`)}
         />
         <MenuBarExtra.Item
           title="My Projects"
           shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
           icon={GitpodIcons.project_icon}
-          onAction={() => open("https://gitpod.io/projects")}
+          onAction={() => open(`${gitpodEndpoint}/projects`)}
         />
         <MenuBarExtra.Item
           title="My Settings"
           shortcut={{ modifiers: ["cmd", "shift"], key: "s" }}
           icon={GitpodIcons.settings_icon}
-          onAction={() => open("https://gitpod.io/user/account")}
+          onAction={() => open(`${gitpodEndpoint}/user/account`)}
         />
         <MenuBarExtra.Item
           title="Documentation"

--- a/src/preferences/gitpod_endpoint.tsx
+++ b/src/preferences/gitpod_endpoint.tsx
@@ -4,3 +4,13 @@ export function getGitpodEndpoint(): string {
   const { gitpodUrl } = getPreferenceValues();
   return gitpodUrl;
 }
+
+export function getPublicAPIEndpoint(): string {
+  const { gitpodUrl } = getPreferenceValues();
+  return gitpodUrl.replace("https://", "https://api.");
+}
+
+export function getWebsocketEndpoint(): string {
+  const { gitpodUrl } = getPreferenceValues();
+  return gitpodUrl.replace("https://", "wss://");
+}


### PR DESCRIPTION
This PR fixes a regression in the extension where the Gitpod URL that a user might supply in the extension preferences wasn't used everywhere in the code-base.

Specifically, if you used a custom Gitpod URL and supplied a Personal Access Token, then you'd get an error about the PAT being invalid when trying to use the Manage Workspaces command. This is because it would try to validate the PAT against gitpod.io rather than the custom Gitpod endpoint the user provided ☺️

This PR should fix all hardcoded references to gitpod.io.

Unfortunately I haven't been able to test this change. When I'm running `npm run dev` and try to use the extension it wants me to authenticate with GitHub, and when I do I get an error. Any idea how to fix this?

![Screenshot 2023-11-06 at 15 19 33](https://github.com/gitpod-samples/Gitpod-Raycast-Extension/assets/83561/52e9f7df-520e-4b97-8721-3902042138be)
page:

