### PR TITLE
Add support for using a monochrome icon for Menu Bar Workspaces

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -90,6 +90,7 @@ export const GitpodIcons = {
     tintColor: statusColors.running,
   },
 
+  gitpod_logo_monochrome: { source: "logo-mark.svg", tintColor: Color.PrimaryText },
   gitpod_logo_primary: { source: "logo-mark.svg" },
   gitpod_logo_secondary: { source: "logo-mark.svg", tintColor: statusColors.stopped },
   github_untracked: {source: "Icons/file-diff.svg", tintColor: UIColors.grey},

--- a/package.json
+++ b/package.json
@@ -130,6 +130,26 @@
         "recent repositories",
         "menubar",
         "workspaces"
+      ],
+      "preferences": [
+        {
+          "name": "menubar_icon_style",
+          "title": "Icon Style",
+          "description": "Pick the style to use for the menubar icon",
+          "required": false,
+          "default": "monochrome",
+          "type": "dropdown",
+          "data": [
+            {
+              "title": "Monochrome",
+              "value": "monochrome"
+            },
+            {
+              "title": "Orange",
+              "value": "orange"
+            }
+          ]
+        }
       ]
     },
     {

--- a/src/menubar_workspaces.tsx
+++ b/src/menubar_workspaces.tsx
@@ -24,6 +24,7 @@ import { splitUrl } from "./helpers/splitURL";
 import { dashboardPreferences } from "./preferences/dashboard_preferences";
 import { getGitpodEndpoint } from "./preferences/gitpod_endpoint";
 import { Preferences } from "./preferences/repository_preferences";
+import * as WorkspaceMenubarPreferences from "./preferences/workspace_menubar_preferences"
 
 export default function command() {
   const preferences = getPreferenceValues<dashboardPreferences>();
@@ -81,7 +82,7 @@ export default function command() {
   const recentWorkspaces = workspaces.filter((workspace) => workspace.getStatus().phase === "PHASE_STOPPED");
 
   return (
-    <MenuBarExtra icon={GitpodIcons.gitpod_logo_primary} isLoading={isLoading}>
+    <MenuBarExtra icon={WorkspaceMenubarPreferences.getIcon()} isLoading={isLoading}>
       {preferences.access_token && !isUnauthorised && (
         <MenuBarExtra.Section title="Active Workspaces">
           {activeWorkspaces.map((workspace) => (

--- a/src/preferences/workspace_menubar_preferences.tsx
+++ b/src/preferences/workspace_menubar_preferences.tsx
@@ -1,0 +1,24 @@
+import { getPreferenceValues } from "@raycast/api";
+
+import { GitpodIcons } from "../../constants";
+
+export interface WorkspaceMenubarPreferences {
+  name: "menubar_workspaces"
+  menubar_icon_style: string;
+}
+
+export function getIcon() {
+    const preferences = getPreferenceValues<WorkspaceMenubarPreferences>()
+    switch(preferences.menubar_icon_style) {
+        case "monochrome": {
+            return GitpodIcons.gitpod_logo_monochrome
+        }
+        case "orange": {
+            return GitpodIcons.gitpod_logo_primary
+        }
+        default: {
+            console.error(`Unknown icon style ${preferences.menubar_icon_style}. Falling back to orange`)
+            return GitpodIcons.gitpod_logo_primary
+        }
+    }
+}


### PR DESCRIPTION
This PR makes it possible to use a monochrome icon for Menu Bar Workspaces. It also uses the monochrome icon as the default to blend in more with the standard MacOS experience. 

A few screenshots:

![Screenshot 2023-11-23 at 11 49 08](https://github.com/gitpod-samples/Gitpod-Raycast-Extension/assets/83561/26f44e74-6272-45c8-86ee-4b401d8dbd35)
![Screenshot 2023-11-23 at 11 49 14](https://github.com/gitpod-samples/Gitpod-Raycast-Extension/assets/83561/47e15c78-b854-4a6e-83a6-17d4a6730538)

