### PR TITLE
Set tint color of icons used in workspace menu bar

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -70,9 +70,10 @@ export const GitpodIcons = {
   stopped_icon_menubar: { source: "Icons/status_icon_small.png", tintColor: statusColors.stopped },
   failed_icon_menubar: { source: "Icons/status_icon_small.png", tintColor: statusColors.failed },
   progressing_icon_menubar: { source: "Icons/status_icon_small.png", tintColor: statusColors.progressing },
-  settings_icon: {source: "Icons/settings.png"},
-  project_icon: {source: "Icons/projects.png"},
-  docs_icon: {source: "Icons/documentation.png"},
+  settings_icon: {source: "Icons/settings.png", tintColor: Color.PrimaryText,},
+  project_icon: {source: "Icons/projects.png", tintColor: Color.PrimaryText,},
+  docs_icon: {source: "Icons/documentation.png", tintColor: Color.PrimaryText,},
+  dashboard_icon: { source: "Icons/dashboard1.png", tintColor: Color.PrimaryText },
 
   repoIcon : {
     source: "Icons/repo-16.svg",
@@ -83,7 +84,6 @@ export const GitpodIcons = {
   link_icon: { source: "Icons/link.svg", tintColor: UIColors.gitpod_gold},
 
   commit_icon: {source: "Icons/git-commit.svg", tintColor: UIColors.gitpod_gold},
-  dashboard_icon: {source: "Icons/dashboard1.png"},
 
   branch_icon: {
     source: "Icons/merge.svg",


### PR DESCRIPTION
This sets the tint color for the icons used in the Menu Bar Workspaces command. This fixes an issue where the icons would be white and look off when using the Light System Appearance in macOS Sonoma.

## Before (from the develop branch)

<img width="782" alt="Screenshot 2023-11-25 at 19 00 22" src="https://github.com/gitpod-samples/Gitpod-Raycast-Extension/assets/83561/115d3fd6-d91f-416f-b201-b083485c11e7">
<img width="786" alt="Screenshot 2023-11-25 at 19 00 29" src="https://github.com/gitpod-samples/Gitpod-Raycast-Extension/assets/83561/084636e5-28d8-423c-99ca-867126aa1c3c">

## After (from this branch)

<img width="807" alt="Screenshot 2023-11-25 at 18 57 23" src="https://github.com/gitpod-samples/Gitpod-Raycast-Extension/assets/83561/60326db5-5b71-4885-bd87-5f80e5fe0890">
<img width="773" alt="Screenshot 2023-11-25 at 18 57 38" src="https://github.com/gitpod-samples/Gitpod-Raycast-Extension/assets/83561/cdf495c5-6f54-4ef0-8f8e-5d53075760c0">
