### PR TITLE
Update configure command menu label

### DIFF
--- a/src/menubar.tsx
+++ b/src/menubar.tsx
@@ -160,7 +160,7 @@ export default function command() {
         <MenuBarExtra.Item title="Documentation" shortcut={{ modifiers: ["cmd", "shift"], key: "." }} icon={GitpodIcons.docs_icon} onAction={() => open("https://www.gitpod.io/docs/introduction")} />
       </MenuBarExtra.Section>
       <MenuBarExtra.Section>
-        <MenuBarExtra.Item title="Command Preferences" shortcut={{ modifiers: ["cmd"], key: "," }} onAction={async () => await openExtensionPreferences()} />
+        <MenuBarExtra.Item title="Configure Command" shortcut={{ modifiers: ["cmd"], key: "," }} onAction={async () => await openExtensionPreferences()} />
       </MenuBarExtra.Section>
     </MenuBarExtra>
   );


### PR DESCRIPTION
The most common label used for accessing command settings is _Configure Command_, not _Command Preferences_.

<img width="413" alt="Screenshot 2023-11-29 at 22 05 44" src="https://github.com/gitpod-samples/Gitpod-Raycast-Extension/assets/120486/0c1fb722-0ef0-4a36-879c-0b2e30cf1b75">
